### PR TITLE
Add shift-based statistics and fix admin menu indexing

### DIFF
--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -54,6 +54,56 @@ foreach ($orders as $orderObj) {
 // Convert associative map to indexed array for the template
 $dashboard = array_values($dashboardMap);
 
+// Build product sales breakdown by shift
+$orderItemHandler = icms_getModuleHandler('orderitem', $moduleDir);
+$allOrderItems = $orderItemHandler->getObjects(new icms_db_criteria_Compo(), true);
+
+$productSalesMap = array(); // shift_key => [product_name => {qty, revenue}]
+
+foreach ($allOrderItems as $itemObj) {
+    $orderId = (int)$itemObj->getVar('order_id');
+
+    // Find the order to get its shift
+    $order = $orderHandler->get($orderId);
+    if (!$order || $order->isNew()) {
+        continue;
+    }
+
+    $shiftName = trim((string)$order->getVar('shift'));
+    $shiftName = $shiftName !== '' ? $shiftName : 'Unassigned';
+    $shiftKey = $shiftName;
+
+    $productName = (string)$itemObj->getVar('product_name');
+    $quantity = (int)$itemObj->getVar('quantity');
+    $price = (float)$itemObj->getVar('product_price');
+    $revenue = $quantity * $price;
+
+    if (!isset($productSalesMap[$shiftKey])) {
+        $productSalesMap[$shiftKey] = array();
+    }
+
+    if (!isset($productSalesMap[$shiftKey][$productName])) {
+        $productSalesMap[$shiftKey][$productName] = array(
+            'product_name' => $productName,
+            'total_quantity' => 0,
+            'total_revenue' => 0.0,
+        );
+    }
+
+    $productSalesMap[$shiftKey][$productName]['total_quantity'] += $quantity;
+    $productSalesMap[$shiftKey][$productName]['total_revenue'] += $revenue;
+}
+
+// Convert to indexed array format for template
+$productSalesBreakdown = array();
+foreach ($productSalesMap as $shiftKey => $products) {
+    $productSalesBreakdown[] = array(
+        'shift_key' => $shiftKey,
+        'shift_name' => $shiftKey,
+        'products' => array_values($products),
+    );
+}
+
 // Include template (presentation logic only)
 global $icmsAdminTpl;
 if (!isset($icmsAdminTpl) || !is_object($icmsAdminTpl)) {
@@ -64,6 +114,7 @@ if (!isset($icmsAdminTpl) || !is_object($icmsAdminTpl)) {
     }
 }
 $icmsAdminTpl->assign('dashboard', $dashboard);
+$icmsAdminTpl->assign('productSalesBreakdown', $productSalesBreakdown);
 $icmsAdminTpl->display('db:simplecart_admin_dashboard.html');
 
 icms_cp_footer();

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -1,10 +1,69 @@
 <?php
+// File: src/admin/index.php
+// Uses ImpressCMS handlers to build $dashboard and includes the template.
+
 include_once __DIR__ . '/header.php';
 icms_cp_header();
+
+icms::$module->displayAdminMenu(0, 'SimpleCart');
+
 echo '<h1>' . _MI_SIMPLECART_NAME . '</h1>';
-echo '<ul>';
-echo '<li><a href="product.php">' . _MI_SIMPLECART_MENU_PRODUCTS . '</a></li>';
-echo '<li><a href="order.php">' . _MI_SIMPLECART_MENU_ORDERS . '</a></li>';
-echo '</ul>';
+
+// Handlers (module dirname assumed 'simplecart' — adjust if different)
+$moduleDir = 'simplecart';
+$orderHandler = icms_getModuleHandler('order', $moduleDir);
+
+// Fetch shifts
+// Fetch all orders and group by their 'shift' field (no separate shift handler)
+$criteria = new icms_db_criteria_Compo();
+$orders = $orderHandler->getObjects($criteria, true);
+
+$dashboardMap = array();
+foreach ($orders as $orderObj) {
+    $shiftName = trim((string)$orderObj->getVar('shift'));
+    $shiftName = $shiftName !== '' ? $shiftName : 'Unassigned';
+    $shiftKey = $shiftName; // use the raw shift string as parameter
+
+    if (!isset($dashboardMap[$shiftKey])) {
+        $dashboardMap[$shiftKey] = array(
+            'shift_key' => $shiftKey,
+            'shift_name' => $shiftName,
+            'total_orders' => 0,
+            'total_amount' => 0.0,
+            'paid_orders' => 0,
+            'paid_amount' => 0.0,
+            'pending_orders' => 0,
+            'pending_amount' => 0.0,
+        );
+    }
+
+   $amount = (float)$orderObj->getVar('total_amount');
+   $status = (string)$orderObj->getVar('status');
+
+   $dashboardMap[$shiftKey]['total_orders']++;
+   $dashboardMap[$shiftKey]['total_amount'] += $amount;
+   if ($status === 'paid') {
+       $dashboardMap[$shiftKey]['paid_orders']++;
+       $dashboardMap[$shiftKey]['paid_amount'] += $amount;
+   } elseif ($status === 'pending') {
+       $dashboardMap[$shiftKey]['pending_orders']++;
+       $dashboardMap[$shiftKey]['pending_amount'] += $amount;
+   }
+}
+
+// Convert associative map to indexed array for the template
+$dashboard = array_values($dashboardMap);
+
+// Include template (presentation logic only)
+global $icmsAdminTpl;
+if (!isset($icmsAdminTpl) || !is_object($icmsAdminTpl)) {
+    // Ensure admin template object exists (ImpressCMS usually provides this)
+    // If not available, fall back to creating a new admin view instance
+    if (class_exists('icms_view_Admin')) {
+        $icmsAdminTpl = new icms_view_Admin();
+    }
+}
+$icmsAdminTpl->assign('dashboard', $dashboard);
+$icmsAdminTpl->display('db:simplecart_admin_dashboard.html');
+
 icms_cp_footer();
-?>

--- a/src/admin/menu.php
+++ b/src/admin/menu.php
@@ -1,6 +1,8 @@
 <?php
 $adminmenu = array();
-$adminmenu[0]['title'] = _MI_SIMPLECART_MENU_PRODUCTS;
-$adminmenu[0]['link']  = 'admin/product.php';
-$adminmenu[1]['title'] = _MI_SIMPLECART_MENU_ORDERS;
-$adminmenu[1]['link']  = 'admin/order.php';
+$adminmenu[0]['title'] = 'Dashboard';
+$adminmenu[0]['link']  = 'admin/index.php';
+$adminmenu[1]['title'] = _MI_SIMPLECART_MENU_PRODUCTS;
+$adminmenu[1]['link']  = 'admin/product.php';
+$adminmenu[2]['title'] = _MI_SIMPLECART_MENU_ORDERS;
+$adminmenu[2]['link']  = 'admin/order.php';

--- a/src/admin/order.php
+++ b/src/admin/order.php
@@ -13,6 +13,9 @@ if ((!isset($_REQUEST['op']) || $clean_op === 'list' || $clean_op === '') && $or
 switch ($clean_op) {
     case 'view':
         icms_cp_header();
+
+        icms::$module->displayAdminMenu(0, 'SimpleCart');
+
         global $icmsAdminTpl;
         $obj = $icms_order_handler->get($order_id);
         if ($obj && !$obj->isNew()) {
@@ -77,8 +80,39 @@ switch ($clean_op) {
     default:
         icms_cp_header();
         global $icmsAdminTpl;
+
+        // Build criteria from request filters so the table honors URL parameters
+        $criteria = new icms_db_criteria_Compo();
+
+        // Filter by shift (accept raw string, fall back to "Unassigned" handling in other places)
+        if (isset($_REQUEST['shift']) && $_REQUEST['shift'] !== '') {
+            $shift = trim((string)$_REQUEST['shift']);
+            // Use equality filter on the 'shift' field
+            $criteria->add(new icms_db_criteria_Item('shift', $shift));
+        }
+
+        // Filter by status — only allow 'pending' or 'paid' (empty = no filter)
+        $allowed_status = array('pending', 'paid');
+        if (isset($_REQUEST['status']) && $_REQUEST['status'] !== '') {
+            $status = strtolower(trim($_REQUEST['status']));
+            if (in_array($status, $allowed_status, true)) {
+                $criteria->add(new icms_db_criteria_Item('status', $status));
+            }
+        }
+
         // Read-only list: remove default edit/delete actions
         $objectTable = new icms_ipf_view_Table($icms_order_handler, false, array());
+
+        // Try to attach the criteria in a compatible way with multiple IPF versions
+        if (method_exists($objectTable, 'setCriteria')) {
+            $objectTable->setCriteria($criteria);
+        } elseif (method_exists($objectTable, 'setFilter')) {
+            $objectTable->setFilter($criteria);
+        } else {
+            // fallback: try recreating with criteria as 4th ctor arg (some IPF variants accept this)
+            $objectTable = new icms_ipf_view_Table($icms_order_handler, false, array(), $criteria);
+        }
+
         $objectTable->addColumn(new icms_ipf_view_Column('order_id', 'center', 60));
         $objectTable->addColumn(new icms_ipf_view_Column('timestamp', 'center', 160));
         $objectTable->addColumn(new icms_ipf_view_Column('status', 'center', 120));

--- a/src/admin/order.php
+++ b/src/admin/order.php
@@ -14,7 +14,7 @@ switch ($clean_op) {
     case 'view':
         icms_cp_header();
 
-        icms::$module->displayAdminMenu(0, 'SimpleCart');
+        icms::$module->displayAdminMenu(2, 'SimpleCart');
 
         global $icmsAdminTpl;
         $obj = $icms_order_handler->get($order_id);
@@ -79,6 +79,7 @@ switch ($clean_op) {
 
     default:
         icms_cp_header();
+        icms::$module->displayAdminMenu(0, 'SimpleCart');
         global $icmsAdminTpl;
 
         // Build criteria from request filters so the table honors URL parameters

--- a/src/admin/product.php
+++ b/src/admin/product.php
@@ -13,24 +13,33 @@ function simplecart_admin_edit_product($product_id = 0) {
     $icmsAdminTpl->display('db:simplecart_admin_product.html.tpl');
     icms_cp_footer();
 }
-
 switch ($clean_op) {
     case 'mod':
+        icms_cp_header();
+        icms::$module->displayAdminMenu(0, 'SimpleCart');
         simplecart_admin_edit_product($product_id);
+        icms_cp_footer();
         break;
 
     case 'addproduct':
+        icms_cp_header();
+        icms::$module->displayAdminMenu(0, 'SimpleCart');
         $controller = new icms_ipf_Controller($icms_product_handler);
         $controller->storeFromDefaultForm(_AM_SIMPLECART_PRODUCT_CREATED, _AM_SIMPLECART_PRODUCT_UPDATED, 'product.php');
+        icms_cp_footer();
         break;
 
     case 'del':
+        icms_cp_header();
+        icms::$module->displayAdminMenu(0, 'SimpleCart');
         $controller = new icms_ipf_Controller($icms_product_handler);
         $controller->handleObjectDeletion(_AM_SIMPLECART_PRODUCT_DELETE_CONFIRM);
+        icms_cp_footer();
         break;
 
     default:
         icms_cp_header();
+        icms::$module->displayAdminMenu(0, 'SimpleCart');
         global $icmsAdminTpl;
         $objectTable = new icms_ipf_view_Table($icms_product_handler);
         $objectTable->addColumn(new icms_ipf_view_Column('name', _GLOBAL_LEFT, 200));

--- a/src/icms_version.php
+++ b/src/icms_version.php
@@ -3,7 +3,7 @@ if (!defined('ICMS_ROOT_PATH')) { die('ImpressCMS root path not defined'); }
 
 $modversion = array();
 $modversion['name'] = _MI_SIMPLECART_NAME;
-$modversion['version'] = '1.2.0';
+$modversion['version'] = '1.2.1';
 $modversion['description'] = _MI_SIMPLECART_DESC;
 $modversion['author'] = 'Augment Agent';
 $modversion['credits'] = 'ImpressCMS, IPF';

--- a/src/icms_version.php
+++ b/src/icms_version.php
@@ -3,14 +3,14 @@ if (!defined('ICMS_ROOT_PATH')) { die('ImpressCMS root path not defined'); }
 
 $modversion = array();
 $modversion['name'] = _MI_SIMPLECART_NAME;
-$modversion['version'] = '1.1.4';
+$modversion['version'] = '1.2.0';
 $modversion['description'] = _MI_SIMPLECART_DESC;
 $modversion['author'] = 'Augment Agent';
 $modversion['credits'] = 'ImpressCMS, IPF';
 $modversion['license'] = 'MIT';
 $modversion['dirname'] = 'simplecart';
 $modversion['image'] = 'assets/images/module_logo.png';
-
++
 $modversion['hasMain'] = 1;
 $modversion['hasAdmin'] = 1;
 $modversion['system_menu'] = 1;
@@ -27,8 +27,9 @@ $modversion['tables'] = array(
 $modversion['templates'][] = array('file' => 'simplecart_index.html', 'description' => 'SimpleCart Front Index');
 $modversion['templates'][] = array('file' => 'simplecart_checkout.html', 'description' => 'SimpleCart Checkout');
 $modversion['templates'][] = array('file' => 'simplecart_order_confirm.html', 'description' => 'SimpleCart Order Confirmation');
-$modversion['templates'][] = array('file' => 'simplecart_admin_product.html', 'description' => 'Admin - Products');
+$modversion['templates'][] = array('file' => 'simplecart_admin_product.html.tpl', 'description' => 'Admin - Products');
 $modversion['templates'][] = array('file' => 'simplecart_admin_order.html', 'description' => 'Admin - Orders');
+$modversion['templates'][] = array('file' => 'simplecart_admin_dashboard.html', 'description' => 'Admin - Dashboard');
 
 $modversion['hasSearch'] = 0;
 $modversion['hasComments'] = 0;

--- a/src/templates/simplecart_admin_dashboard.html
+++ b/src/templates/simplecart_admin_dashboard.html
@@ -53,4 +53,34 @@
         </tbody>
     </table>
     <{/if}>
+
+    <!-- Product Sales Breakdown by Shift -->
+    <{if $productSalesBreakdown}>
+    <h2 style="margin-top: 2em;">Product Sales Breakdown by Shift</h2>
+    <{foreach from=$productSalesBreakdown item=shiftData}>
+        <h3 style="margin-top: 1.5em;">Shift: <{$shiftData.shift_name|default:''|escape:'html'}></h3>
+        <{if $shiftData.products|@count > 0}>
+        <table class="table">
+            <thead>
+            <tr>
+                <th>Product Name</th>
+                <th style="text-align: right;">Total Quantity</th>
+                <th style="text-align: right;">Total Revenue</th>
+            </tr>
+            </thead>
+            <tbody>
+            <{foreach from=$shiftData.products item=product}>
+                <tr>
+                    <td><{$product.product_name|default:''|escape:'html'}></td>
+                    <td style="text-align: right;"><{$product.total_quantity|default:0|escape:'html'}></td>
+                    <td style="text-align: right;"><{$product.total_revenue|default:0|number_format:2:'.':','|escape:'html'}></td>
+                </tr>
+            <{/foreach}>
+            </tbody>
+        </table>
+        <{else}>
+        <p>No products sold in this shift.</p>
+        <{/if}>
+    <{/foreach}>
+    <{/if}>
 </div>

--- a/src/templates/simplecart_admin_dashboard.html
+++ b/src/templates/simplecart_admin_dashboard.html
@@ -1,0 +1,56 @@
+<div class="simplecart-admin-dashboard">
+    <{if !$dashboard}>
+    <p>No dashboard data.</p>
+    <{else}>
+    <table class="table">
+        <thead>
+        <tr>
+            <th>Shift</th>
+                <th>Total Orders</th>
+                <th>Total Amount</th>
+                <th>Paid Orders</th>
+                <th>Paid Amount</th>
+                <th>Pending Orders</th>
+                <th>Pending Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+        <{foreach from=$dashboard item=row}>
+            <tr>
+                <td><{$row.shift_name|default:''|escape:'html'}></td>
+
+                <td>
+                    <a href="order.php?shift=<{$row.shift_key|escape:'url'}>">
+                        <{$row.total_orders|default:0|escape:'html'}>
+                    </a>
+                </td>
+
+                <td>
+                    <{$row.total_amount|default:0|number_format:2:'.':','|escape:'html'}>
+                </td>
+
+                <td>
+                    <a href="order.php?shift=<{$row.shift_key|escape:'url'}>&amp;status=paid">
+                        <{$row.paid_orders|default:0|escape:'html'}>
+                    </a>
+                </td>
+
+                <td>
+                    <{$row.paid_amount|default:0|number_format:2:'.':','|escape:'html'}>
+                </td>
+
+                <td>
+                    <a href="order.php?shift=<{$row.shift_key|escape:'url'}>&amp;status=pending">
+                        <{$row.pending_orders|default:0|escape:'html'}>
+                    </a>
+                </td>
+
+                <td>
+                    <{$row.pending_amount|default:0|number_format:2:'.':','|escape:'html'}>
+                </td>
+            </tr>
+        <{/foreach}>
+        </tbody>
+    </table>
+    <{/if}>
+</div>


### PR DESCRIPTION
### Summary

This pull request enhances the admin dashboard by introducing shift-based order and sales statistics for better data insights. It also fixes a display issue in the admin menu's index within the order management section. 

### Changes

- Adds shift-based order breakdown to the admin dashboard.
- Includes sales breakdown per shift on the admin dashboard.
- Updates module version to 1.2.0 and 1.2.1 in separate steps for feature tracking.
- Fixes admin menu index display issue in order management sections.

### Checklist

- [ ] Documentation has been updated as needed.
- [ ] Unit tests have been added or updated.
- [ ] Code changes follow coding standards and best practices.
- [ ] No new warnings or errors have been introduced.
- [ ] All project tests pass successfully.